### PR TITLE
Fix braces in IR processing

### DIFF
--- a/bgw_flipper_ir_serial.c
+++ b/bgw_flipper_ir_serial.c
@@ -49,9 +49,8 @@ static void process_ir(FlameTunnelState* s, InfraredWorkerSignal* sig, uint32_t 
         infrared_worker_get_raw_signal(sig, &timings, &count);
         len += snprintf(buf + len, sizeof(buf) - len, "IR[%u]:", (unsigned int)count);
         for(size_t i = 0; i < count && len < (int)sizeof(buf) - 10; i++) {
-    len += snprintf(buf + len, sizeof(buf) - len, " %lu", timings[i]);
-       }
-}
+            len += snprintf(buf + len, sizeof(buf) - len, " %lu", timings[i]);
+        }
         len += snprintf(buf + len, sizeof(buf) - len, "\r\n");
     } else {
         len = snprintf(buf, MAX_BUF, "RNG:%lu\r\n", (unsigned long)rng);


### PR DESCRIPTION
## Summary
- fix the braces in `process_ir`

## Testing
- `./fbt fap_bgw_flipper_ir_serial` *(fails: Do not know how to make File target)*
- `./fbt COMPACT=1 DEBUG=0 updater_package` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68528735bd0c8320b866ccdee6a138d2